### PR TITLE
Potential fix for code scanning alert no. 30: User-controlled data in arithmetic expression

### DIFF
--- a/java/0040_boolean_operations.java
+++ b/java/0040_boolean_operations.java
@@ -11,6 +11,15 @@ class rectangle_or_cylinder {
     System.out.print("Enter the second number: ");
     double num2 = scanner.nextDouble();
 
+    // Basic validation: dimensions should be finite and non-negative
+    if (Double.isNaN(num1) || Double.isInfinite(num1)
+        || Double.isNaN(num2) || Double.isInfinite(num2)
+        || num1 < 0.0 || num2 < 0.0) {
+      System.out.println("Invalid input: dimensions must be finite, non-negative numbers.");
+      scanner.close();
+      return;
+    }
+
     System.out.print("Enter a boolean value (true/false): ");
     boolean isRectangle = scanner.nextBoolean();
 
@@ -25,6 +34,18 @@ class rectangle_or_cylinder {
 
       double height = num1;
       double radius = num2;
+
+      // Guard against overflow/underflow in surface area and volume calculations
+      // Use a conservative upper bound for dimensions to keep results within double range.
+      double maxDimensionForVolume = Math.cbrt(Double.MAX_VALUE / Math.PI);
+      double maxDimensionForSurfaceArea = Math.sqrt(Double.MAX_VALUE / (4.0 * Math.PI));
+      double maxDimension = Math.min(maxDimensionForVolume, maxDimensionForSurfaceArea);
+
+      if (radius > maxDimension || height > maxDimension) {
+        System.out.println("Input too large: radius and height must be less than or equal to " + maxDimension);
+        scanner.close();
+        return;
+      }
 
       double surfaceArea = 2 * Math.PI * radius * (radius + height);
       double volume = Math.PI * Math.pow(radius, 2) * height;


### PR DESCRIPTION
Potential fix for [https://github.com/DibyajyotiBiswal57/programs/security/code-scanning/30](https://github.com/DibyajyotiBiswal57/programs/security/code-scanning/30)

In general, to fix this problem we should validate user input and/or guard the arithmetic operations so that we only perform them when the operands are within a safe range. For doubles, that means ensuring `radius` and `height` are finite, non-negative (for geometric dimensions), and not so large in magnitude that the resulting surface area and volume calculations will overflow to infinities or underflow in unexpected ways. If inputs are invalid, we should report the issue and avoid performing the calculation.

The best targeted fix here, without changing existing functionality for normal values, is:
- Validate `num1` and `num2` right after reading them:
  - Ensure they are finite (`!Double.isNaN(...)` and `!Double.isInfinite(...)`).
  - Ensure they are non-negative (dimensions should not be negative).
- For the cylinder branch, compute safe upper bounds for `radius` and `height` to avoid overflow:
  - For surface area: `surfaceArea = 2 * Math.PI * r * (r + h)`; require `r` and `h` small enough that this stays below `Double.MAX_VALUE`.
  - For volume: `volume = Math.PI * r^2 * h`; require `r` and `h` such that `Math.PI * r^2 * h <= Double.MAX_VALUE`.
  - A simple and clear approach is to pre-compute a conservative `MAX_DIMENSION` based on `Double.MAX_VALUE` and `Math.PI`, and reject inputs above that.
- If inputs fail these checks, print an error and skip the calculation instead of performing the multiplication.

Practically, this means editing `java/0040_boolean_operations.java`:
- After reading `num1` and `num2`, add validation for finiteness and non-negativity.
- Inside the cylinder `else` branch, before computing `surfaceArea` and `volume`, add a guard that checks `radius` and `height` against a safely derived upper bound and only performs the calculations when safe; otherwise, print a message and return.
- No new imports are needed; we already import `java.util.Scanner`, and we only use `java.lang` and `java.lang.Math` which are available by default.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
